### PR TITLE
Fix/makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,10 @@ install:
 	$(CURR_DIR)/git-hooks/install_symlinks.sh
 	mkdir -p /usr/local/share/man/man1
 	install -m "0644" target/man/git-team.1.gz /usr/local/share/man/man1/git-team.1.gz
-	install -m "0644" bash_completion/git-team.bash $(BASH_COMPLETION_PREFIX)/etc/bash_completion.d/git-team
-	@echo "[INFO] Don't forget to source $(BASH_COMPLETION_PREFIX)/etc/bash_completion"
+	@if [ -d "/etc/bash_completion.d" ]; then \
+		install -m "0644" bash_completion/git-team.bash $(BASH_COMPLETION_PREFIX)/etc/bash_completion.d/git-team; \
+		echo "[INFO] Don't forget to source $(BASH_COMPLETION_PREFIX)/etc/bash_completion"; \
+	fi
 
 uninstall:
 	rm -f $(BIN_PREFIX)/bin/git-team

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ install:
 	$(CURR_DIR)/git-hooks/install_symlinks.sh
 	mkdir -p /usr/local/share/man/man1
 	install -m "0644" target/man/git-team.1.gz /usr/local/share/man/man1/git-team.1.gz
-	@if [ -d "/etc/bash_completion.d" ]; then \
+	@if [ -d "$(BASH_COMPLETION_PREFIX)/etc/bash_completion.d" ]; then \
 		install -m "0644" bash_completion/git-team.bash $(BASH_COMPLETION_PREFIX)/etc/bash_completion.d/git-team; \
 		echo "[INFO] Don't forget to source $(BASH_COMPLETION_PREFIX)/etc/bash_completion"; \
 	fi

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -102,6 +102,12 @@ sudo rpm -i /path/to/downloaded/release.rpm
 sudo xbps-install git-team
 ```
 
+## Arch Linux
+Install from the [AUR](https://aur.archlinux.org/packages/git-team-git/)
+```bash
+yay git-team-git
+```
+
 ## Build from source
 The latest version of git-team has been built against go version 1.12.
 ```bash


### PR DESCRIPTION
For non-bash users the installation fails, while attempting to install auto-completions in non-existent directory.
Added a conditional to fix that.

---

### required for all prs:
- [ ] Adhered to
   - [DRY](http://programmer.97things.oreilly.com/wiki/index.php/Don%27t_Repeat_Yourself);
   - The [Boy Scout Rule](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule).
- [ ] Has appropriate unit tests.

### required only for more thorough changes:
- [ ] Made sure there is a corresponding ticket in the project's [issue tracker](https://github.com/retel-io/ari-proxy/issues).
- [ ] Made sure the ticket has been discussed and prioritized by the team.
