### PR TITLE
fix: replace echo with printf for shell compatibility

### DIFF
--- a/src/command/enable/hookscript/content.go
+++ b/src/command/enable/hookscript/content.go
@@ -75,9 +75,9 @@ case "${commit_source}" in
                 exit 0
         fi
 
-        echo -e -n "\n\n" >> $template
+        printf "\n\n" >> $template
         git config ${gitconfig_scope_flag} --get-all team.state.active-coauthors | while read coauthor; do
-                echo -e -n "Co-authored-by: $coauthor\n" >> $template
+                printf "Co-authored-by: $coauthor\n" >> $template
         done
         ;;
 *)


### PR DESCRIPTION
On macOS the `prepare-commit-msg-git-team.sh` script writes echo parameters `-e -n` in addition to the lines of co-authors. Due to better portability, echo is replaced by printf.