### PR TITLE
Add `--json` flag for the `status` sub-command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ./git-team
 target/
 mocks/
+.idea/

--- a/acceptance-tests.Dockerfile
+++ b/acceptance-tests.Dockerfile
@@ -29,7 +29,7 @@ RUN go mod download
 COPY src ./src
 COPY main.go .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go install ./...
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go install ./...
 
 # ----------------------------------------------------------------- #
 

--- a/acceptance-tests/disable_global.bats
+++ b/acceptance-tests/disable_global.bats
@@ -72,7 +72,7 @@ teardown() {
 	assert_line "ls: /home/git-team-acceptance-test/.git-team/commit-templates/global/COMMIT_TEMPLATE: No such file or directory"
 }
 
-@test "git-team: (scope: global) disable should treat a previously disabled git-team idempotently" {
+@test "git-team: (scope: global) disable should treat a previously disabled git-team in an idempotent way" {
 	run /usr/local/bin/git-team disable
 	assert_success
 	assert_line "git-team disabled"

--- a/acceptance-tests/disable_repo_local.bats
+++ b/acceptance-tests/disable_repo_local.bats
@@ -85,7 +85,7 @@ teardown() {
 	assert_line "ls: /home/git-team-acceptance-test/.git-team/commit-templates/repo-local/$REPO_CHECKSUM: No such file or directory"
 }
 
-@test "git-team: (scope: repo-local) disable should treat a previously disabled git-team idempotently" {
+@test "git-team: (scope: repo-local) disable should treat a previously disabled git-team in an idempotent way" {
 	run /usr/local/bin/git-team disable
 	assert_success
 	assert_line "git-team disabled"

--- a/acceptance-tests/status_global.bats
+++ b/acceptance-tests/status_global.bats
@@ -13,7 +13,7 @@ setup() {
 	assert_line 'git-team disabled'
 }
 
-@test 'git-team: (scope: global) status should properly disaplay the enabled status' {
+@test 'git-team: (scope: global) status should properly display the enabled status' {
 	/usr/local/bin/git-team enable 'A <a@x.y>' 'B <b@x.y>' 'C <c@x.y>'
 
 	run /usr/local/bin/git-team status

--- a/acceptance-tests/status_global.bats
+++ b/acceptance-tests/status_global.bats
@@ -27,3 +27,13 @@ setup() {
 	/usr/local/bin/git-team disable
 }
 
+@test 'git-team: (scope: global) status should properly display the enabled status in a json format' {
+	/usr/local/bin/git-team enable 'A <a@x.y>' 'B <b@x.y>' 'C <c@x.y>'
+
+	run /usr/local/bin/git-team status --json
+	assert_success
+	assert_line --index 0 '{"status":"enabled","coAuthors":["A \u003ca@x.y\u003e","B \u003cb@x.y\u003e","C \u003cc@x.y\u003e"],"previousHooksPath":""}'
+
+	/usr/local/bin/git-team disable
+}
+

--- a/acceptance-tests/status_global.bats
+++ b/acceptance-tests/status_global.bats
@@ -32,7 +32,7 @@ setup() {
 
 	run /usr/local/bin/git-team status --json
 	assert_success
-	assert_line --index 0 '{"status":"enabled","coAuthors":["A \u003ca@x.y\u003e","B \u003cb@x.y\u003e","C \u003cc@x.y\u003e"],"previousHooksPath":""}'
+	assert_line --index 0 '{"status":"enabled","coAuthors":["A <a@x.y>","B <b@x.y>","C <c@x.y>"],"previousHooksPath":""}'
 
 	/usr/local/bin/git-team disable
 }

--- a/acceptance-tests/status_repo_local.bats
+++ b/acceptance-tests/status_repo_local.bats
@@ -49,7 +49,7 @@ teardown() {
 
 	run /usr/local/bin/git-team status --json
 	assert_success
-	assert_line --index 0 '{"status":"enabled","coAuthors":["A \u003ca@x.y\u003e","B \u003cb@x.y\u003e","C \u003cc@x.y\u003e"],"previousHooksPath":""}'
+	assert_line --index 0 '{"status":"enabled","coAuthors":["A <a@x.y>","B <b@x.y>","C <c@x.y>"],"previousHooksPath":""}'
 
 	/usr/local/bin/git-team disable
 }

--- a/acceptance-tests/status_repo_local.bats
+++ b/acceptance-tests/status_repo_local.bats
@@ -30,7 +30,7 @@ teardown() {
 	assert_line 'git-team disabled'
 }
 
-@test 'git-team: (scope: repo-local) status should properly disaplay the enabled status' {
+@test 'git-team: (scope: repo-local) status should properly display the enabled status' {
 	/usr/local/bin/git-team enable 'A <a@x.y>' 'B <b@x.y>' 'C <c@x.y>'
 
 	run /usr/local/bin/git-team status
@@ -44,6 +44,15 @@ teardown() {
 	/usr/local/bin/git-team disable
 }
 
+@test 'git-team: (scope: repo-local) status should properly display the enabled status' {
+	/usr/local/bin/git-team enable 'A <a@x.y>' 'B <b@x.y>' 'C <c@x.y>'
+
+	run /usr/local/bin/git-team status --json
+	assert_success
+	assert_line --index 0 '{"status":"enabled","coAuthors":["A \u003ca@x.y\u003e","B \u003cb@x.y\u003e","C \u003cc@x.y\u003e"],"previousHooksPath":""}'
+
+	/usr/local/bin/git-team disable
+}
 
 @test 'git-team: (scope: repo-local) status should fail when not inside a git repository' {
 	cd /tmp

--- a/hookscript-tests.Dockerfile
+++ b/hookscript-tests.Dockerfile
@@ -29,7 +29,7 @@ RUN go mod download
 COPY src ./src
 COPY main.go .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go install ./...
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go install ./...
 
 # ----------------------------------------------------------------- #
 

--- a/src/command/disable/cliadapter/cmd/cmd_mapper.go
+++ b/src/command/disable/cliadapter/cmd/cmd_mapper.go
@@ -21,7 +21,7 @@ func Command() *cli.Command {
 		Name:  "disable",
 		Usage: "Use default commit template and remove prepare-commit-msg hook",
 		Action: func(c *cli.Context) error {
-			return commandadapter.Run(policy(), disableeventadapter.MapEventToEffectFactory(statuscmdmapper.Policy()))
+			return commandadapter.Run(policy(), disableeventadapter.MapEventToEffectFactory(statuscmdmapper.Policy(false)))
 		},
 	}
 }

--- a/src/command/enable/cliadapter/cmd/cmd_mapper.go
+++ b/src/command/enable/cliadapter/cmd/cmd_mapper.go
@@ -32,7 +32,7 @@ func Command() *cli.Command {
 		Action: func(c *cli.Context) error {
 			coauthors := c.Args().Slice()
 			useAll := c.Bool("all")
-			return commandadapter.Run(policy(&coauthors, &useAll), enableeventadapter.MapEventToEffectFactory(statuscmdmapper.Policy()))
+			return commandadapter.Run(policy(&coauthors, &useAll), enableeventadapter.MapEventToEffectFactory(statuscmdmapper.Policy(false)))
 		},
 		BashComplete: func(c *cli.Context) {
 			remainingAliases := aliascompletion.NewAliasShellCompletion(gitconfig.NewDataSource()).Complete(c.Args().Slice())

--- a/src/command/status/cliadapter/cmd/cmd_mapper.go
+++ b/src/command/status/cliadapter/cmd/cmd_mapper.go
@@ -17,19 +17,25 @@ func Command() *cli.Command {
 	return &cli.Command{
 		Name:  "status",
 		Usage: "Print the current status",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{Name: "json", Value: false, Usage: "Display the current status as a JSON formatted struct"},
+		},
 		Action: func(c *cli.Context) error {
-			return commandadapter.Run(Policy(), statuseventadapter.MapEventToEffect)
+			stateAsJson := c.Bool("json")
+
+			return commandadapter.Run(Policy(stateAsJson), statuseventadapter.MapEventToEffect)
 		},
 	}
 }
 
 // Policy the status policy constructor
-func Policy() status.Policy {
+func Policy(stateAsJson bool) status.Policy {
 	return status.Policy{
 		Deps: status.Dependencies{
 			ConfigReader:        config.NewGitconfigDataSource(gitconfig.NewDataSource()),
 			StateReader:         state.NewGitConfigDataSource(gitconfig.NewDataSource()),
 			ActivationValidator: activation.NewGitConfigDataSource(gitconfig.NewDataSource()),
+			StateAsJson:         stateAsJson,
 		},
 	}
 }

--- a/src/command/status/cliadapter/event/event_mapper.go
+++ b/src/command/status/cliadapter/event/event_mapper.go
@@ -2,6 +2,7 @@ package statuseventadapter
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"sort"
 
@@ -17,6 +18,9 @@ import (
 func MapEventToEffect(event events.Event) effects.Effect {
 	switch evt := event.(type) {
 	case status.StateRetrievalSucceeded:
+		if evt.StateAsJson {
+			return effects.NewExitOkMsg(toJson(evt.State))
+		}
 		return effects.NewExitOkMsg(toString(evt.State))
 	case status.StateRetrievalFailed:
 		return effects.NewExitErrMsg(evt.Reason)
@@ -42,5 +46,15 @@ func toString(theState state.State) string {
 		}
 	}
 
+	return buffer.String()
+}
+
+func toJson(theState state.State) string {
+	var buffer bytes.Buffer
+	jsonData, err := json.Marshal(theState)
+	if err != nil {
+		return buffer.String()
+	}
+	buffer.Write(jsonData)
 	return buffer.String()
 }

--- a/src/command/status/cliadapter/event/event_mapper.go
+++ b/src/command/status/cliadapter/event/event_mapper.go
@@ -55,7 +55,7 @@ func toJson(theState state.State) string {
 	encoder.SetEscapeHTML(false)
 	err := encoder.Encode(theState)
 	if err != nil {
-		return buffer.String()
+		effects.NewExitErrMsg(err)
 	}
 	return buffer.String()
 }

--- a/src/command/status/cliadapter/event/event_mapper.go
+++ b/src/command/status/cliadapter/event/event_mapper.go
@@ -19,7 +19,7 @@ func MapEventToEffect(event events.Event) effects.Effect {
 	switch evt := event.(type) {
 	case status.StateRetrievalSucceeded:
 		if evt.StateAsJson {
-			return effects.NewExitOkMsg(toJson(evt.State))
+			return toJson(evt.State)
 		}
 		return effects.NewExitOkMsg(toString(evt.State))
 	case status.StateRetrievalFailed:
@@ -49,13 +49,13 @@ func toString(theState state.State) string {
 	return buffer.String()
 }
 
-func toJson(theState state.State) string {
+func toJson(theState state.State) effects.Effect {
 	var buffer bytes.Buffer
 	encoder := json.NewEncoder(&buffer)
 	encoder.SetEscapeHTML(false)
 	err := encoder.Encode(theState)
 	if err != nil {
-		effects.NewExitErrMsg(err)
+		return effects.NewExitErrMsg(err)
 	}
-	return buffer.String()
+	return effects.NewExitOkMsg(buffer.String())
 }

--- a/src/command/status/cliadapter/event/event_mapper.go
+++ b/src/command/status/cliadapter/event/event_mapper.go
@@ -51,10 +51,11 @@ func toString(theState state.State) string {
 
 func toJson(theState state.State) string {
 	var buffer bytes.Buffer
-	jsonData, err := json.Marshal(theState)
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(theState)
 	if err != nil {
 		return buffer.String()
 	}
-	buffer.Write(jsonData)
 	return buffer.String()
 }

--- a/src/command/status/events.go
+++ b/src/command/status/events.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"fmt"
 	state "github.com/hekmekk/git-team/src/shared/state/entity"
 )
 
@@ -8,6 +9,10 @@ import (
 type StateRetrievalSucceeded struct {
 	State       state.State
 	StateAsJson bool
+}
+
+func (s StateRetrievalSucceeded) String() string {
+	return fmt.Sprintf("%s", s.State)
 }
 
 // StateRetrievalFailed failed to get the current state

--- a/src/command/status/events.go
+++ b/src/command/status/events.go
@@ -6,7 +6,8 @@ import (
 
 // StateRetrievalSucceeded successfully got the current state
 type StateRetrievalSucceeded struct {
-	State state.State
+	State       state.State
+	StateAsJson bool
 }
 
 // StateRetrievalFailed failed to get the current state

--- a/src/command/status/policy.go
+++ b/src/command/status/policy.go
@@ -15,6 +15,7 @@ type Dependencies struct {
 	StateReader         state.Reader
 	ConfigReader        config.Reader
 	ActivationValidator activation.Validator
+	StateAsJson         bool
 }
 
 // Policy the policy to apply
@@ -42,5 +43,5 @@ func (policy Policy) Apply() events.Event {
 		return StateRetrievalFailed{Reason: fmt.Errorf("failed to query current state: %s", stateRepositoryQueryErr)}
 	}
 
-	return StateRetrievalSucceeded{State: retState}
+	return StateRetrievalSucceeded{State: retState, StateAsJson: deps.StateAsJson}
 }

--- a/src/command/status/policy.go
+++ b/src/command/status/policy.go
@@ -37,10 +37,10 @@ func (policy Policy) Apply() events.Event {
 		return StateRetrievalFailed{Reason: fmt.Errorf("failed to get status with activation-scope=%s: not inside a git repository", activationScope)}
 	}
 
-	state, stateRepositoryQueryErr := deps.StateReader.Query(cfg.ActivationScope)
+	retState, stateRepositoryQueryErr := deps.StateReader.Query(cfg.ActivationScope)
 	if stateRepositoryQueryErr != nil {
 		return StateRetrievalFailed{Reason: fmt.Errorf("failed to query current state: %s", stateRepositoryQueryErr)}
 	}
 
-	return StateRetrievalSucceeded{State: state}
+	return StateRetrievalSucceeded{State: retState}
 }

--- a/src/shared/state/entity/state.go
+++ b/src/shared/state/entity/state.go
@@ -9,9 +9,9 @@ const (
 
 // State the state of git-team
 type State struct {
-	Status            teamStatus
-	Coauthors         []string
-	PreviousHooksPath string
+	Status            teamStatus `json:"status"`
+	Coauthors         []string   `json:"coAuthors"`
+	PreviousHooksPath string     `json:"previousHooksPath"`
 }
 
 // NewStateEnabled the constructor for the enabled state


### PR DESCRIPTION
This PR combines two different things since the first one was mandatory for me for actually testing my changes:

1. The commit 7b751bf allows the test containers to also be run on Mx-based Macs as well. There were some hard coded architecture flags I had to switch to a some more dynamic ones as well as use generic container images which are also provided with `arm64` architecture.
2. The actual change I wanted to provide is in the other commits. They add a `--json` flag to the `git-team status` command. This prints out the same information as without this flag but in a machine-readable format.

Happy to discuss the proposed changes 🥳 