### PR TITLE
docs: update adding apt-sourc.es gpg key instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,7 +43,7 @@ The debian package is made available via [apt-sourc.es](https://apt-sourc.es).
 
 1. Add *apt-sourc.es* GPG Key
 ```shell
-curl -fsSL https://apt-sourc.es/admin/gpg.asc | sudo apt-key add -
+curl -fsSL https://apt-sourc.es/admin/gpg.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/git-team.gpg
 ```
 
 2. Setup the `apt` repository


### PR DESCRIPTION
Currently the docs suggest using `apt-key` which is deprecated sind Debian 11 and Ubuntu 22.04. This updates the docs to show how to install the key on current versions.